### PR TITLE
:sparkles: feat(#30) API 에러 표준 설정 방식

### DIFF
--- a/backend/src/main/java/org/example/common/exceptionCore/ApiErrorCategory.java
+++ b/backend/src/main/java/org/example/common/exceptionCore/ApiErrorCategory.java
@@ -1,0 +1,35 @@
+package org.example.common.exceptionCore;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+
+@Getter
+public enum ApiErrorCategory {
+	/** ---------------------------------------------------------------
+	 *     비즈니스 로직에서 발생하는 모든 에러는 ApiErrorCategory로 정의합니다.
+	 *   - API_ERROR_SYMBOL_EXAMPLE ( HTTP 상태 코드, "에러 카테고리" )
+	 * ----------------------------------------------------------------*/
+	INVALID_BOARD(HttpStatus.BAD_REQUEST, "게시판 카테고리 오류"),
+	BOARD_NOT_FOUND(HttpStatus.NOT_FOUND, "게시판 조회 불가"),
+	ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "게시글 조회 불가"),
+	COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글 조회 불가"),
+	UNAUTHORIZED_VIEWER(HttpStatus.UNAUTHORIZED, "권한 없음"),
+	;
+
+	private final HttpStatus errorStatusCode;
+	private final String errorCategoryName;
+
+	ApiErrorCategory(HttpStatus errorStatusCode, String errorCategoryName) {
+		this.errorStatusCode = errorStatusCode;
+		this.errorCategoryName = errorCategoryName;
+	}
+
+	@Override
+	public String toString() {
+		return String.format("%s [분류: %s]",
+			this.errorStatusCode,
+			this.errorCategoryName
+		);
+	}
+}

--- a/backend/src/main/java/org/example/common/exceptionCore/ApiErrorResponse.java
+++ b/backend/src/main/java/org/example/common/exceptionCore/ApiErrorResponse.java
@@ -1,0 +1,32 @@
+package org.example.common.exceptionCore;
+
+import org.springframework.http.ProblemDetail;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import lombok.Getter;
+
+/**
+ * Response Error Message Body Format
+ * RFC 7807 - "Problem Detail"
+ */
+@Getter
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class ApiErrorResponse extends ProblemDetail {
+	@JsonProperty(value = "error_data")
+	private final Object generatedErrorBody;
+
+	protected ApiErrorResponse(ApiException apiException) {
+		super(ProblemDetail.forStatusAndDetail(
+			apiException.getHttpStatus(),
+			apiException.getMessage()
+		));
+		this.generatedErrorBody = apiException.generateErrorBody();
+	}
+
+	public static ApiErrorResponse from(ApiException apiException) {
+		return new ApiErrorResponse(apiException);
+	}
+}

--- a/backend/src/main/java/org/example/common/exceptionCore/ApiException.java
+++ b/backend/src/main/java/org/example/common/exceptionCore/ApiException.java
@@ -1,0 +1,35 @@
+package org.example.common.exceptionCore;
+
+import java.util.Optional;
+
+import org.springframework.http.HttpStatus;
+
+import jakarta.annotation.Nullable;
+import lombok.Builder;
+
+public class ApiException extends RuntimeException {
+	private final ApiErrorCategory apiErrorCategory;
+	private final ErrorDetailSupplier errorDetailSupplier;
+
+	@Builder
+	protected ApiException(
+		ApiErrorCategory category,
+		String detail,
+		@Nullable ErrorDetailSupplier setErrorData
+	) {
+		super(detail);
+		this.apiErrorCategory = category;
+		this.errorDetailSupplier = setErrorData;
+	}
+
+	public HttpStatus getHttpStatus() {
+		return this.apiErrorCategory.getErrorStatusCode();
+	}
+
+	public Optional<Object> generateErrorBody() {
+		if (this.errorDetailSupplier != null) {
+			return Optional.of(this.errorDetailSupplier.get());
+		}
+		return Optional.empty();
+	}
+}

--- a/backend/src/main/java/org/example/common/exceptionCore/ErrorDetailSupplier.java
+++ b/backend/src/main/java/org/example/common/exceptionCore/ErrorDetailSupplier.java
@@ -1,0 +1,6 @@
+package org.example.common.exceptionCore;
+
+import java.util.function.Supplier;
+
+public interface ErrorDetailSupplier extends Supplier<Object> {
+}


### PR DESCRIPTION
##### ApiException을 상속해서 Exception을 새롭게 정의할 수 있습니다.
CustomException 방식과 ErrorCode 방식을 적절히 혼합하면 될 것 같습니다.

아래는 기본적인 사용 방식입니다.
```java
boardRepository.findByCategory(articleCreateRequestDto.getBoardCategory())
    .map(board -> articleRepository.save(
        ArticleMapper.toEntity(articleCreateRequestDto, board)
    )).orElseThrow(() ->
        ApiException.builder()
                .category( ApiErrorCategory.INVALID_BOARD )
                .detail( "존재하지 않는 게시판 카테고리입니다." )
                .setErrorData( () -> List.of(1, 'K', "Error3") )  // 원하는 데이터를 예외를 던지는 코드에서 람다로 전달합니다. (안넣어줘도 됩니다)
                .build()
    );
```

![image](https://github.com/user-attachments/assets/7ce3e0c7-d217-443a-b665-7933064cb447)

```java
INVALID_BOARD ( HttpStatus.BAD_REQUEST, "게시판 카테고리 오류" )
// 여기서 "게시판 카테고리 오류"는 일단 ErrorResponse에 넣지 않았습니다. 추후 바꿀 수 있습니다.
```
