### PR TITLE
[Refactor] Post querydsl 및 controller 리팩토링

### DIFF
--- a/backend/src/main/java/org/example/config/WebOAuthSecurityConfig.java
+++ b/backend/src/main/java/org/example/config/WebOAuthSecurityConfig.java
@@ -8,6 +8,7 @@ import org.example.user.repository.token.RefreshTokenRepository;
 import org.example.user.service.member.UserService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -57,8 +58,9 @@ public class WebOAuthSecurityConfig {
 			.addFilterBefore(tokenAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class)
 			.authorizeHttpRequests(auth -> auth
 				.requestMatchers("/api/token").permitAll()
-				.requestMatchers("/posts/**", "/image/**").permitAll() // TODO: 나중에 GET만 permit 되도록 꼭!!! 수정 필요.
-				.requestMatchers("/api/**").hasRole("USER")
+				.requestMatchers("/image/**").permitAll() // TODO: 나중에 GET만 permit 되도록 꼭!!! 수정 필요.
+				.requestMatchers("/api/a1/**").permitAll()
+				.requestMatchers("/api/v1/**").hasRole("USER")
 				.anyRequest().permitAll())
 			.oauth2Login(oauth2 -> oauth2
 				.loginPage("/login")

--- a/backend/src/main/java/org/example/post/controller/PostApiController.java
+++ b/backend/src/main/java/org/example/post/controller/PostApiController.java
@@ -1,7 +1,12 @@
 package org.example.post.controller;
 
 import org.example.post.domain.dto.PostDto;
+import org.example.post.repository.custom.PostSearchCondition;
 import org.example.post.service.PostService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -27,6 +32,7 @@ public class PostApiController {
 
 	private final PostService postService;
 
+	// Permit Only User
 	@Operation(summary = "게시글 작성 API", description = "사용자가 게시글을 작성할 수 있다.")
 	@ApiResponses({
 		@ApiResponse(responseCode = "200", description = "ok!!"),
@@ -42,12 +48,5 @@ public class PostApiController {
 		return ResponseEntity.status(HttpStatus.CREATED).body(post);
 	}
 
-	@GetMapping("/posts/{post_id}")
-	public ResponseEntity<PostDto.PostDetailDtoResponse> getPostById(
-		@PathVariable Long post_id
-	) {
-		return ResponseEntity.status(HttpStatus.OK)
-			.body(postService.getPostById(post_id));
-	}
 
 }

--- a/backend/src/main/java/org/example/post/controller/PostPublicController.java
+++ b/backend/src/main/java/org/example/post/controller/PostPublicController.java
@@ -1,14 +1,17 @@
 package org.example.post.controller;
 
 import org.example.post.domain.dto.PostDto;
-import org.example.post.repository.PostRepository;
 import org.example.post.repository.custom.PostSearchCondition;
 import org.example.post.service.PostService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -17,17 +20,32 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 
 @RestController
+@RequestMapping("/api/a1")
 @RequiredArgsConstructor
-public class PostController {
-	private final PostRepository postRepository;
+public class PostPublicController {
+	private final PostService postService;
 
+	// Permit All
 	@Operation(summary = "게시글 조회 API", description = "모든 게시글 조회 및 해시태그, 검색 키워드로 조회 가능하다.")
 	@ApiResponses({
 		@ApiResponse(responseCode = "200", description = "ok!!"),
 		@ApiResponse(responseCode = "404", description = "Resource not found!!")
 	})
 	@GetMapping("/posts")
-	public Page<PostDto.PostDtoResponse> searchPost(@PageableDefault(page = 0, size = 10, sort = "createdAt", direction = Sort.Direction.DESC) PostSearchCondition condition, Pageable pageable) {
-		return postRepository.search(condition, pageable);
+	public ResponseEntity<Page<PostDto.PostDtoResponse>> searchPost(
+		@PageableDefault(page = 0, size = 10, sort = "createdAt", direction = Sort.Direction.DESC) PostSearchCondition postSearchCondition,
+		Pageable pageable
+	) {
+		return ResponseEntity.status(HttpStatus.OK)
+			.body(postService.findAllPosts(postSearchCondition, pageable));
+	}
+
+	// Permit All
+	@GetMapping("/posts/{post_id}")
+	public ResponseEntity<PostDto.PostDetailDtoResponse> getPostById(
+		@PathVariable Long post_id
+	) {
+		return ResponseEntity.status(HttpStatus.OK)
+			.body(postService.getPostById(post_id));
 	}
 }

--- a/backend/src/main/java/org/example/post/domain/dto/PostDto.java
+++ b/backend/src/main/java/org/example/post/domain/dto/PostDto.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.example.post.domain.entity.HashtagEntity;
 import org.example.post.domain.entity.PostEntity;
@@ -21,7 +22,7 @@ public class PostDto {
 		@JsonProperty("hashtag_content")
 		String hashtagContents
 	) {
-
+		// Split and Convert String to List<HashtagEntity>
 		public List<HashtagEntity> getHashtagEntityFromString(String hashtagContent, String regex) {
 			List<String> hashtagContentList = splitString(hashtagContent, regex);
 			return hashtagContentList.stream()
@@ -29,6 +30,7 @@ public class PostDto {
 				.map(HashtagEntity::new).collect(Collectors.toList());
 		}
 
+		// Split and Convert String to List<String>
 		public List<String> convertHashtagContents(String hashtagContents, String regex) {
 			return Arrays.stream(hashtagContents.split(regex))
 				.filter(s -> !s.isEmpty())
@@ -79,7 +81,7 @@ public class PostDto {
 			Integer likeCount,
 			LocalDateTime createdAt,
 			LocalDateTime updatedAt
-		){
+		) {
 			this.nickname = nickname;
 			this.postId = postId;
 			this.imageId = imageId;
@@ -103,42 +105,34 @@ public class PostDto {
 			);
 		}
 	}
-
-
 	public record PostDtoResponse(
 		String nickname,
 		Long postId,
-		Long imageId
-		// List<String> hashtagContents
+		Long imageId,
+		List<String> hashtags
 	) {
 
+		// Canonical Constructor
 		@QueryProjection
 		public PostDtoResponse(
 			String nickname,
 			Long postId,
-			Long imageId
-
-		){
-			this.nickname = nickname;
-			this.postId = postId;
-			this.imageId = imageId;
-			// this.hashtagContents = hashtagContents;
+			Long imageId,
+			String hashtagContent
+		) {
+			this(nickname, postId, imageId, splitHashtags(hashtagContent));
 		}
 
-		public static PostDtoResponse toDto(PostEntity postEntity) {
-			return new PostDtoResponse(
-				postEntity.getUser().getNickname(),
-				postEntity.getPostId(),
-				postEntity.getImageId()
-				// postEntity.getHashtagContents() != null ? postEntity.getHashtagContents() : Collections.emptyList()
-			);
+		// Helper Method to split hashtagContent into List<String>
+		private static List<String> splitHashtags(String hashtagContent) {
+			if (hashtagContent == null || hashtagContent.isEmpty()) {
+				return List.of();
+			}
+			return Stream.of(hashtagContent.split("#"))
+				.filter(s -> !s.isEmpty())
+				.collect(Collectors.toList());
 		}
 	}
-
-
-
-
-
 
 
 }

--- a/backend/src/main/java/org/example/post/repository/custom/PostSearchCondition.java
+++ b/backend/src/main/java/org/example/post/repository/custom/PostSearchCondition.java
@@ -7,5 +7,5 @@ import lombok.Data;
 @Data
 public class PostSearchCondition {
 	private String postContent;
-
+	private String hashtags;
 }

--- a/backend/src/main/java/org/example/post/service/PostService.java
+++ b/backend/src/main/java/org/example/post/service/PostService.java
@@ -9,15 +9,13 @@ import org.example.image.storageManager.imageStorageManager.ImageStorageManager;
 import org.example.post.domain.dto.PostDto;
 import org.example.post.domain.entity.HashtagEntity;
 import org.example.post.domain.entity.PostEntity;
-import org.example.post.domain.enums.PostStatus;
 import org.example.post.repository.HashtagRepository;
 import org.example.post.repository.PostRepository;
+import org.example.post.repository.custom.PostSearchCondition;
 import org.example.user.domain.entity.member.UserEntity;
 import org.example.user.repository.member.UserRepository;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -62,6 +60,12 @@ public class PostService {
 		postRepository.save(postEntity);
 
 		return PostDto.CreatePostDtoResponse.toDto(savedPost);
+	}
+
+	public Page<PostDto.PostDtoResponse> findAllPosts(
+		PostSearchCondition postSearchCondition, Pageable pageable
+	) {
+		return postRepository.search(postSearchCondition, pageable);
 	}
 
 	public PostDto.PostDetailDtoResponse getPostById(Long postId) {


### PR DESCRIPTION
#80 
- security 경로, 역할 수정
- controller를 역할에 따라 나눔
    - /api/v1/posts 로그인 유저
    - /api/a1/posts 모든 유저
- searchPost에서 바로 respository 호출하던 것을 서비스단으로 옮김
- PostDtoResponse에서 hashtag도 받아올 수 있도록 매개 변수 추가
    - QueryDSL 로 인해 타입을 HashtagEntity로 맞추어야 해서 String으로 받고 dto 내부에서 분리해서 List<String>으로 리턴
- 검색 조건 PostSearchCondition 에 hashtag 추가
- PostRepositoryImpl search 에서 검색 조건 업데이트
    1.  postContent는 일부 내용만 포함되도 검색 가능
    2. hashtag는 해시태그 내용이 모두 일치해야 검색 가능
    3. 둘 다 없을 경우 전체 게시글 검색
    4. 두 조건이 들어왔을 때 모두 일치하지 않으면 리턴하는 게시물 없음
    5. hashtag가 여러 개 포함된 게시물을 검색하는 경우 postId 기준으로 묶어서 하나의 게시물로 리턴