### PR TITLE
[리팩토링] 기존 ResourceLocationId를 ImageLocationId로 변경

### DIFF
--- a/backend/src/main/java/org/example/config/jwt/TokenProvider.java
+++ b/backend/src/main/java/org/example/config/jwt/TokenProvider.java
@@ -62,9 +62,10 @@ public class TokenProvider { // 계속해서 토큰을 생성하고 올바른 �
 	// 토큰 기반으로 인증 정보를 가져오는 메서드
 	public Authentication getAuthentication(String token) {
 		Claims claims = getClaims(token);
+		String roleClaim = claims.get("role", String.class);
 
 		Set<SimpleGrantedAuthority> authorities = Collections.singleton(
-			new SimpleGrantedAuthority((String)claims.get("role"))
+			new SimpleGrantedAuthority(roleClaim == null ? "ROLE_NONE" : roleClaim)
 		);
 
 		var user = new org.springframework.security.core.userdetails.User(

--- a/backend/src/main/java/org/example/exception/storage/ApiStorageErrorSubCategory.java
+++ b/backend/src/main/java/org/example/exception/storage/ApiStorageErrorSubCategory.java
@@ -4,7 +4,7 @@ import org.example.exception.common.ApiErrorSubCategory;
 
 public enum ApiStorageErrorSubCategory implements ApiErrorSubCategory {
 
-	RESOURCE_LOCATION_NOT_FOUND("[ResourceLocationRepository] 리소스의 위치 정보가 존재하지 않습니다."),
+	RESOURCE_LOCATION_NOT_FOUND("[ImageLocationRepository] 리소스의 위치 정보가 존재하지 않습니다."),
 
 	DIRECTORY_NOT_ACCESSIBLE("디렉토리가 존재하지 않습니다."),
 

--- a/backend/src/main/java/org/example/follow/domain/dto/FollowDto.java
+++ b/backend/src/main/java/org/example/follow/domain/dto/FollowDto.java
@@ -18,6 +18,6 @@ public class FollowDto {
 	public record FollowUser(
 		String nickname,
 		int followersCount,
-		Long profileImageId
+		Long profileImageLocationId
 	) {}
 }

--- a/backend/src/main/java/org/example/follow/service/FollowService.java
+++ b/backend/src/main/java/org/example/follow/service/FollowService.java
@@ -70,7 +70,7 @@ public class FollowService {
 							.map((following) -> new FollowDto.FollowUser(
 								following.getNickname(),
 								this.getFollowerCountOfUser(following),
-								following.getProfileImageId()
+								following.getProfileImageLocationId()
 							)).toList()
 		);
 	}
@@ -85,7 +85,7 @@ public class FollowService {
 							.map((follower) -> new FollowDto.FollowUser(
 								follower.getNickname(),
 								this.getFollowerCountOfUser(follower),
-								follower.getProfileImageId()
+								follower.getProfileImageLocationId()
 							)).toList()
 		);
 	}

--- a/backend/src/main/java/org/example/image/ImageAnalyzeManager/ImageAnalyzeManager.java
+++ b/backend/src/main/java/org/example/image/ImageAnalyzeManager/ImageAnalyzeManager.java
@@ -6,9 +6,9 @@ import org.example.image.ImageAnalyzeManager.type.ImageAnalyzeData;
 public interface ImageAnalyzeManager {
 
 	// analyze image and store to DB
-	void analyze(Long resourceLocationId) throws IOException;
+	void analyze(Long imageLocationId) throws IOException;
 
 	// get analyzed data from DB
-	ImageAnalyzeData getAnalyzedData(Long resourceLocationId);
+	ImageAnalyzeData getAnalyzedData(Long imageLocationId);
 
 }

--- a/backend/src/main/java/org/example/image/ImageAnalyzeManager/ImageAnalyzeManagerImpl/ImageAnalyzeManagerImpl.java
+++ b/backend/src/main/java/org/example/image/ImageAnalyzeManager/ImageAnalyzeManagerImpl/ImageAnalyzeManagerImpl.java
@@ -12,7 +12,7 @@ import org.example.image.ImageAnalyzeManager.analyzer.tools.ColorConverter;
 import org.example.image.ImageAnalyzeManager.analyzer.type.ClothAnalyzeData;
 import org.example.image.ImageAnalyzeManager.type.ImageAnalyzeData;
 import org.example.image.imageStorageManager.ImageStorageManager;
-import org.example.image.imageStorageManager.type.StorageFindResult;
+import org.example.image.imageStorageManager.type.StorageLoadResult;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
@@ -27,8 +27,8 @@ public class ImageAnalyzeManagerImpl implements ImageAnalyzeManager {
 	private final ImageStorageManager imageStorageManager;
 
 	@Override
-	public void analyze(Long resourceLocationId) throws IOException {
-		StorageFindResult result = imageStorageManager.findResourceById(resourceLocationId);
+	public void analyze(Long imageLocationId) throws IOException {
+		StorageLoadResult result = imageStorageManager.loadImageByLocationId(imageLocationId);
 		byte[] imageBytes = Files.readAllBytes(result.resource().getFile().toPath());
 
 		imageAnalyzeVisionService.analyzeImage(imageBytes)
@@ -46,18 +46,18 @@ public class ImageAnalyzeManagerImpl implements ImageAnalyzeManager {
 								clothAnalyzeResult.rightBottomVertex()
 							)
 						)
-						.resourceLocationId(resourceLocationId)
+						.imageLocationId(imageLocationId)
 						.build()
 				);
 			});
 	}
 
 	@Override
-	public ImageAnalyzeData getAnalyzedData(Long resourceLocationId) {
+	public ImageAnalyzeData getAnalyzedData(Long imageLocationId) {
 
 		// 1. gather pre-analyzed cloth data from db
 		List<ClothAnalyzeData> clothAnalyzeDataList
-			= this.clothAnalyzeDataRepository.findAllByResourceLocationId(resourceLocationId)
+			= this.clothAnalyzeDataRepository.findAllByImageLocationId(imageLocationId)
 			.stream()
 			.map(
 				clothAnalyzeData -> ClothAnalyzeData.builder()

--- a/backend/src/main/java/org/example/image/ImageAnalyzeManager/analyzer/entity/ClothAnalyzeDataEntity.java
+++ b/backend/src/main/java/org/example/image/ImageAnalyzeManager/analyzer/entity/ClothAnalyzeDataEntity.java
@@ -6,7 +6,6 @@ import org.example.image.ImageAnalyzeManager.analyzer.type.ClothType;
 import org.example.image.ImageAnalyzeManager.analyzer.type.LabColor;
 import org.example.image.ImageAnalyzeManager.analyzer.type.NormalizedVertex2D;
 import org.example.image.ImageAnalyzeManager.analyzer.type.RGBColor;
-import org.example.image.imageStorageManager.storage.entity.ResourceLocationEntity;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
@@ -14,12 +13,9 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -42,8 +38,8 @@ public class ClothAnalyzeDataEntity {
 	/**
 	 * 분석한 대상 리소스 id
 	 */
-	@Column(name = "resouce_location_id", nullable = false)
-	private Long resourceLocationId;
+	@Column(name = "image_location_id", nullable = false)
+	private Long imageLocationId;
 
 	/**
 	 * 어떤 옷 타입 인가? (ex. 상의, 하의, 모자)
@@ -102,13 +98,13 @@ public class ClothAnalyzeDataEntity {
 		LabColor labColor,
 		RGBColor rgbColor,
 		List<NormalizedVertex2D> boundingBox,
-		Long resourceLocationId
+		Long imageLocationId
 	) {
 		this.clothType = clothType;
 		this.clothName = clothName;
 		this.labColor = labColor;
 		this.rgbColor = rgbColor;
 		this.boundingBox = boundingBox;
-		this.resourceLocationId = resourceLocationId;
+		this.imageLocationId = imageLocationId;
 	}
 }

--- a/backend/src/main/java/org/example/image/ImageAnalyzeManager/analyzer/repository/ClothAnalyzeDataRepository.java
+++ b/backend/src/main/java/org/example/image/ImageAnalyzeManager/analyzer/repository/ClothAnalyzeDataRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ClothAnalyzeDataRepository extends JpaRepository<ClothAnalyzeDataEntity, Integer> {
 
-	List<ClothAnalyzeDataEntity> findAllByResourceLocationId(Long ResourceLocationId);
+	List<ClothAnalyzeDataEntity> findAllByImageLocationId(Long imageLocationId);
 }

--- a/backend/src/main/java/org/example/image/imageStorageManager/ImageStorageManager.java
+++ b/backend/src/main/java/org/example/image/imageStorageManager/ImageStorageManager.java
@@ -3,7 +3,7 @@ package org.example.image.imageStorageManager;
 import java.io.IOException;
 
 import org.example.image.imageStorageManager.storage.service.core.StorageType;
-import org.example.image.imageStorageManager.type.StorageFindResult;
+import org.example.image.imageStorageManager.type.StorageLoadResult;
 import org.example.image.imageStorageManager.type.StorageSaveResult;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -20,16 +20,16 @@ public interface ImageStorageManager {
 	 *
 	 * @see StorageType
 	 */
-	StorageSaveResult saveResource(MultipartFile resource, StorageType storageType) throws IOException;
+	StorageSaveResult saveImage(MultipartFile resource, StorageType storageType) throws IOException;
 
 	/**
 	 * <p> 리소스 식별자를 통해서 {@link MultipartFile}을 획득 합니다.</p>
-	 * <p> {@link StorageFindResult}를 참고 해주세요.</p>
+	 * <p> {@link StorageLoadResult}를 참고 해주세요.</p>
 	 *
-	 * @param resourceId 저장된 리소스 파일에 대한 식별자 입니다.
-	 * @return {@link StorageFindResult StorageFindResult} 리소스 검색 결과를 담은 레코드 입니다.
+	 * @param imageLocationId 저장된 리소스 파일에 대한 식별자 입니다.
+	 * @return {@link StorageLoadResult StorageFindResult} 리소스 검색 결과를 담은 레코드 입니다.
 	 * @throws org.example.exception.storage.ApiStorageException 파일 탐색에 실패할 경우 런타임 예외를 발생시킵니다.
 	 */
-	StorageFindResult findResourceById(Long resourceId);
+	StorageLoadResult loadImageByLocationId(Long imageLocationId);
 
 }

--- a/backend/src/main/java/org/example/image/imageStorageManager/imageStorageManagerImpl/ImageStorageManagerImpl.java
+++ b/backend/src/main/java/org/example/image/imageStorageManager/imageStorageManagerImpl/ImageStorageManagerImpl.java
@@ -1,12 +1,10 @@
 package org.example.image.imageStorageManager.imageStorageManagerImpl;
 
-import java.io.IOException;
-
 import org.example.exception.common.ApiErrorCategory;
 import org.example.exception.storage.ApiStorageErrorSubCategory;
 import org.example.exception.storage.ApiStorageException;
-import org.example.image.imageStorageManager.storage.entity.ResourceLocationEntity;
-import org.example.image.imageStorageManager.storage.repository.ResourceLocationRepository;
+import org.example.image.imageStorageManager.storage.entity.ImageLocationEntity;
+import org.example.image.imageStorageManager.storage.repository.ImageLocationRepository;
 import org.example.image.imageStorageManager.storage.service.core.StoragePacket;
 import org.example.image.imageStorageManager.storage.service.core.StorageSaveResultInternal;
 import org.example.image.imageStorageManager.storage.service.core.StorageService;
@@ -14,7 +12,7 @@ import org.example.image.imageStorageManager.storage.service.core.StorageType;
 import org.example.image.imageStorageManager.storage.service.core.strategy.LocalDateDirectoryNamingStrategy;
 import org.example.image.imageStorageManager.storage.service.core.strategy.UuidV4FileNamingStrategy;
 import org.example.image.imageStorageManager.ImageStorageManager;
-import org.example.image.imageStorageManager.type.StorageFindResult;
+import org.example.image.imageStorageManager.type.StorageLoadResult;
 import org.example.image.imageStorageManager.type.StorageSaveResult;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -27,11 +25,11 @@ import lombok.RequiredArgsConstructor;
 public class ImageStorageManagerImpl implements ImageStorageManager {
 
 	// 현재는 Local File System 1개만 사용하며, 추후 변경될 예정입니다.
-	private final ResourceLocationRepository imageRepository;
+	private final ImageLocationRepository imageRepository;
 	private final StorageService storageService;
 
 	@Override
-	public StorageSaveResult saveResource(
+	public StorageSaveResult saveImage(
 		@NonNull MultipartFile file,
 		StorageType storageType
 	) {
@@ -51,8 +49,8 @@ public class ImageStorageManagerImpl implements ImageStorageManager {
 			default -> throw new AssertionError("[미구현 기능] Unsupported storage type: " + storageType);
 		};
 
-		ResourceLocationEntity savedImageLocation = this.imageRepository.save(
-			ResourceLocationEntity
+		ImageLocationEntity savedImageLocation = this.imageRepository.save(
+			ImageLocationEntity
 				.builder()
 				.storageType(storageSaveResult.storageType())
 				.savedPath(storageSaveResult.savedPath().toString())
@@ -61,13 +59,13 @@ public class ImageStorageManagerImpl implements ImageStorageManager {
 
 		return new StorageSaveResult(
 			storageSaveResult.storageType(),
-			savedImageLocation.getResourceLocationId()
+			savedImageLocation.getImageLocationId()
 		);
 	}
 
 	@Override
-	public StorageFindResult findResourceById(Long imageId) {
-		return this.imageRepository.findById(imageId)
+	public StorageLoadResult loadImageByLocationId(Long imageLocationId) {
+		return this.imageRepository.findById(imageLocationId)
 								   .map(
 									   image -> this.storageService.load(image.getSavedPath())
 								   )

--- a/backend/src/main/java/org/example/image/imageStorageManager/storage/controller/ImageApiResourceController.java
+++ b/backend/src/main/java/org/example/image/imageStorageManager/storage/controller/ImageApiResourceController.java
@@ -44,9 +44,9 @@ public class ImageApiResourceController {
 	public ResponseEntity<Long> handleImageUpload(
 		@RequestParam("image") MultipartFile file
 	) throws IOException {
-		StorageSaveResult result = this.imageStorageManager.saveResource(file, StorageType.LOCAL_FILE_SYSTEM);
+		StorageSaveResult result = this.imageStorageManager.saveImage(file, StorageType.LOCAL_FILE_SYSTEM);
 
 		return ResponseEntity.status(HttpStatus.CREATED)
-							 .body(result.resourceLocationId());
+							 .body(result.imageLocationId());
 	}
 }

--- a/backend/src/main/java/org/example/image/imageStorageManager/storage/controller/ImagePublicResourceController.java
+++ b/backend/src/main/java/org/example/image/imageStorageManager/storage/controller/ImagePublicResourceController.java
@@ -1,7 +1,7 @@
 package org.example.image.imageStorageManager.storage.controller;
 
 import org.example.image.imageStorageManager.ImageStorageManager;
-import org.example.image.imageStorageManager.type.StorageFindResult;
+import org.example.image.imageStorageManager.type.StorageLoadResult;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
@@ -38,12 +38,12 @@ public class ImagePublicResourceController {
 		this.imageStorageManager = imageStorageManager;
 	}
 
-	@GetMapping("/image/{resourceId}")
+	@GetMapping("/image/{imageLocationId}")
 	@ResponseBody
 	public ResponseEntity<Resource> serveFile(
-		@PathVariable Long resourceId
+		@PathVariable Long imageLocationId
 	) {
-		StorageFindResult result = this.imageStorageManager.findResourceById(resourceId);
+		StorageLoadResult result = this.imageStorageManager.loadImageByLocationId(imageLocationId);
 
 		return ResponseEntity.ok().header(
 			HttpHeaders.CONTENT_DISPOSITION,

--- a/backend/src/main/java/org/example/image/imageStorageManager/storage/entity/ImageLocationEntity.java
+++ b/backend/src/main/java/org/example/image/imageStorageManager/storage/entity/ImageLocationEntity.java
@@ -17,16 +17,16 @@ import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 
 @Entity
-@Table(name = "resource_location")
+@Table(name = "image_location")
 @Getter
 @NoArgsConstructor(access = AccessLevel.NONE)
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
-public class ResourceLocationEntity {
+public class ImageLocationEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "resource_location_id")
-	private Long resourceLocationId;
+	@Column(name = "image_location_id")
+	private Long imageLocationId;
 
 	@Column(name = "storage_type", nullable = false)
 	@Enumerated(EnumType.STRING)
@@ -36,7 +36,7 @@ public class ResourceLocationEntity {
 	private String savedPath;
 
 	@Builder
-	protected ResourceLocationEntity(
+	protected ImageLocationEntity(
 		StorageType storageType,
 		String savedPath
 	) {

--- a/backend/src/main/java/org/example/image/imageStorageManager/storage/repository/ImageLocationRepository.java
+++ b/backend/src/main/java/org/example/image/imageStorageManager/storage/repository/ImageLocationRepository.java
@@ -1,0 +1,6 @@
+package org.example.image.imageStorageManager.storage.repository;
+
+import org.example.image.imageStorageManager.storage.entity.ImageLocationEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ImageLocationRepository extends JpaRepository<ImageLocationEntity, Long> {}

--- a/backend/src/main/java/org/example/image/imageStorageManager/storage/repository/ResourceLocationRepository.java
+++ b/backend/src/main/java/org/example/image/imageStorageManager/storage/repository/ResourceLocationRepository.java
@@ -1,6 +1,0 @@
-package org.example.image.imageStorageManager.storage.repository;
-
-import org.example.image.imageStorageManager.storage.entity.ResourceLocationEntity;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface ResourceLocationRepository extends JpaRepository<ResourceLocationEntity, Long> {}

--- a/backend/src/main/java/org/example/image/imageStorageManager/storage/service/FileSystemStorage/FileSystemStorage.java
+++ b/backend/src/main/java/org/example/image/imageStorageManager/storage/service/FileSystemStorage/FileSystemStorage.java
@@ -13,7 +13,7 @@ import org.example.image.imageStorageManager.storage.service.core.StoragePacket;
 import org.example.image.imageStorageManager.storage.service.core.StorageSaveResultInternal;
 import org.example.image.imageStorageManager.storage.service.core.StorageService;
 import org.example.image.imageStorageManager.storage.service.core.StorageType;
-import org.example.image.imageStorageManager.type.StorageFindResult;
+import org.example.image.imageStorageManager.type.StorageLoadResult;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.UrlResource;
 import org.springframework.stereotype.Service;
@@ -75,7 +75,7 @@ public class FileSystemStorage implements StorageService {
 	}
 
 	@Override
-	public StorageFindResult load(@NonNull String filePath) {
+	public StorageLoadResult load(@NonNull String filePath) {
 		try {
 			Path fullPath = this.rootLocation.resolve(filePath).normalize().toAbsolutePath();
 			Resource resource = new UrlResource(fullPath.toUri());
@@ -88,7 +88,7 @@ public class FileSystemStorage implements StorageService {
 					.build();
 			}
 
-			return new StorageFindResult(
+			return new StorageLoadResult(
 				StorageType.LOCAL_FILE_SYSTEM,
 				resource
 			);

--- a/backend/src/main/java/org/example/image/imageStorageManager/storage/service/core/StorageService.java
+++ b/backend/src/main/java/org/example/image/imageStorageManager/storage/service/core/StorageService.java
@@ -1,10 +1,10 @@
 package org.example.image.imageStorageManager.storage.service.core;
 
-import org.example.image.imageStorageManager.type.StorageFindResult;
+import org.example.image.imageStorageManager.type.StorageLoadResult;
 
 public interface StorageService {
 
 	StorageSaveResultInternal save(StoragePacket packet);
 
-	StorageFindResult load(String fileUrl);
+	StorageLoadResult load(String fileUrl);
 }

--- a/backend/src/main/java/org/example/image/imageStorageManager/type/StorageLoadResult.java
+++ b/backend/src/main/java/org/example/image/imageStorageManager/type/StorageLoadResult.java
@@ -9,7 +9,7 @@ import lombok.NonNull;
  * @param storageType 저장소 종류 (FileSystem | AmazonS3 | etc ...)
  * @param resource 저장된 Blob 파일 데이터
  */
-public record StorageFindResult(
+public record StorageLoadResult(
 	@NonNull StorageType storageType,
 	@NonNull Resource resource
 ) {

--- a/backend/src/main/java/org/example/image/imageStorageManager/type/StorageSaveResult.java
+++ b/backend/src/main/java/org/example/image/imageStorageManager/type/StorageSaveResult.java
@@ -7,10 +7,10 @@ import lombok.NonNull;
 /**
  *
  * @param storageType 저장소 종류 (FileSystem | AmazonS3 | etc ...)
- * @param resourceLocationId 리소스 위치 id
+ * @param imageLocationId 리소스 위치 id
  */
 public record StorageSaveResult(
 	@NonNull StorageType storageType,
-	@NonNull Long resourceLocationId
+	@NonNull Long imageLocationId
 ) {
 }

--- a/backend/src/main/java/org/example/image/redis/service/ImageRedisService.java
+++ b/backend/src/main/java/org/example/image/redis/service/ImageRedisService.java
@@ -21,7 +21,6 @@ import org.example.post.domain.enums.PostStatus;
 import org.example.post.repository.PostRepository;
 import org.example.post.repository.custom.PostPopularSearchCondition;
 import org.example.post.repository.custom.UpdateScoreType;
-import org.example.post.service.PostService;
 import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
@@ -53,14 +52,14 @@ public class ImageRedisService {
 	private static final Integer WEIGHT_LIKE = 2;
 	private static final Integer WEIGHT_VIEW = 1;
 
-	public List<String> saveNewColor(Long resourceLocationId) throws JsonProcessingException {
+	public List<String> saveNewColor(Long imageLocationId) throws JsonProcessingException {
 		List<String> colorNameList = new ArrayList<>();
 		ColorApiClient client = new ColorApiClient();
 		HashOperations<String, String, String> hashOps = redisTemplate.opsForHash();
 		ZSetOperations<String, Object> zSetOps = redisTemplate.opsForZSet();
 		ObjectMapper objectMapper = new ObjectMapper();
 
-		ImageAnalyzeData imageAnalyzeData = imageAnalyzeManager.getAnalyzedData(resourceLocationId);
+		ImageAnalyzeData imageAnalyzeData = imageAnalyzeManager.getAnalyzedData(imageLocationId);
 
 		for (ClothAnalyzeData clothAnalyzeData : imageAnalyzeData.clothAnalyzeDataList()) {        // Clothes from an image
 			int[] colorRGB = {
@@ -116,7 +115,7 @@ public class ImageRedisService {
 		// get popular color of popular ClothAnalyzeData's image analyze data to change RGB
 		HashMap<String, ColorDto.ColorSelectedDtoRequest> selectedColorHashMap = new HashMap<>();
 		for (PostEntity post : postEntities) {
-			ImageAnalyzeData imageAnalyzeData = imageAnalyzeManager.getAnalyzedData(post.getImageId());
+			ImageAnalyzeData imageAnalyzeData = imageAnalyzeManager.getAnalyzedData(post.getImageLocationId());
 
 			// Selection Colors for updating because we can get several requests about same color
 			for (ClothAnalyzeData clothAnalyzeData : imageAnalyzeData.clothAnalyzeDataList()) {
@@ -208,10 +207,10 @@ public class ImageRedisService {
 		return savedColorNameList;
 	}
 
-	public void updateZSetColorScore(Long resourceLocationId, UpdateScoreType updateScoreType) throws JsonProcessingException {
+	public void updateZSetColorScore(Long imageLocationId, UpdateScoreType updateScoreType) throws JsonProcessingException {
 		ZSetOperations<String, Object> zSetOps = redisTemplate.opsForZSet();
 
-		ImageAnalyzeData imageAnalyzeData = imageAnalyzeManager.getAnalyzedData(resourceLocationId);
+		ImageAnalyzeData imageAnalyzeData = imageAnalyzeManager.getAnalyzedData(imageLocationId);
 		for (ClothAnalyzeData clothAnalyzeData : imageAnalyzeData.clothAnalyzeDataList()) {
 			int[] rgbColor = {
 				clothAnalyzeData.rgbColor().getRed(),

--- a/backend/src/main/java/org/example/post/domain/dto/PostDto.java
+++ b/backend/src/main/java/org/example/post/domain/dto/PostDto.java
@@ -45,7 +45,7 @@ public class PostDto {
 	public record PostDetailDtoResponse(
 		String nickname,
 		Long postId,
-		Long imageId,
+		Long imageLocationId,
 		String postContent,
 		List<String> hashtagContents,
 		int likeCount,
@@ -60,7 +60,7 @@ public class PostDto {
 			return new PostDetailDtoResponse(
 				postEntity.getUser().getNickname(),
 				postEntity.getPostId(),
-				postEntity.getImageId(),
+				postEntity.getImageLocationId(),
 				postEntity.getPostContent(),
 				postEntity.getHashtagContents() != null ? postEntity.getHashtagContents() : Collections.emptyList(),
 				postEntity.getLikeCount(),
@@ -75,7 +75,7 @@ public class PostDto {
 	public record PostDtoResponse(
 		String nickname,
 		Long postId,
-		Long imageId,
+		Long imageLocationId,
 		List<String> hashtags,
 		int likeCount,
 		int hits,
@@ -87,13 +87,13 @@ public class PostDto {
 		public PostDtoResponse(
 			String nickname,
 			Long postId,
-			Long imageId,
+			Long imageLocationId,
 			String hashtagContent,
 			int likeCount,
 			int hits,
 			LocalDateTime createdAt
 		) {
-			this(nickname, postId, imageId, splitHashtags(hashtagContent), likeCount, hits, createdAt);
+			this(nickname, postId, imageLocationId, splitHashtags(hashtagContent), likeCount, hits, createdAt);
 		}
 
 		// Helper Method to split hashtagContent into List<String>
@@ -114,7 +114,7 @@ public class PostDto {
 
 	public record PostMyPageDtoResponse(
 		Long postId,
-		Long imageId,
+		Long imageLocationId,
 		String postContent,
 		List<String> hashtagContents,
 		Integer likeCount,
@@ -125,7 +125,7 @@ public class PostDto {
 		public static PostMyPageDtoResponse toDto(PostEntity postEntity) {
 			return new PostMyPageDtoResponse(
 				postEntity.getPostId(),
-				postEntity.getImageId(),
+				postEntity.getImageLocationId(),
 				postEntity.getPostContent(),
 				postEntity.getHashtagContents(),
 				postEntity.getLikeCount(),

--- a/backend/src/main/java/org/example/post/domain/entity/PostEntity.java
+++ b/backend/src/main/java/org/example/post/domain/entity/PostEntity.java
@@ -52,7 +52,7 @@ public class PostEntity extends TimeTrackableEntity {
 	private UserEntity user;
 
 	@Column(nullable = false)
-	private Long imageId;
+	private Long imageLocationId;
 
 	@Column(name = "post_content", columnDefinition = "VARCHAR(255)")
 	private String postContent;
@@ -83,10 +83,10 @@ public class PostEntity extends TimeTrackableEntity {
 	private LocalDateTime removedAt;
 
 	@Builder
-	public PostEntity(UserEntity user, String postContent, Long imageId, int likeCount) {
+	public PostEntity(UserEntity user, String postContent, Long imageLocationId, int likeCount) {
 		this.user = user;
 		this.postContent = postContent;
-		this.imageId = imageId;
+		this.imageLocationId = imageLocationId;
 		this.likeCount = likeCount;
 	}
 
@@ -98,8 +98,8 @@ public class PostEntity extends TimeTrackableEntity {
 		this.postContent = postContent;
 	}
 
-	public void updateImage(Long imageId) {
-		this.imageId = imageId;
+	public void updateImage(Long imageLocationId) {
+		this.imageLocationId = imageLocationId;
 	}
 
 	public void updateHashtags(List<HashtagEntity> hashtags) {

--- a/backend/src/main/java/org/example/post/repository/custom/PostRepositoryImpl.java
+++ b/backend/src/main/java/org/example/post/repository/custom/PostRepositoryImpl.java
@@ -67,7 +67,7 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
 				userEntity.nickname,
 				postEntity.postId,
 				hashtagEntity.hashtagContent,
-				postEntity.imageId,
+				postEntity.imageLocationId,
 				postEntity.likeCount,
 				postEntity.hits,
 				postEntity.createdAt
@@ -84,14 +84,14 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
 		for (Tuple tuple : results) {
 			String nickname = tuple.get(userEntity.nickname);
 			Long postId = tuple.get(postEntity.postId);
-			Long imageId = tuple.get(postEntity.imageId);
+			Long imageLocationId = tuple.get(postEntity.imageLocationId);
 			String hashtagContent = tuple.get(hashtagEntity.hashtagContent);
 			LocalDateTime createdAt = tuple.get(postEntity.createdAt);
 			int likeCount = Optional.ofNullable(tuple.get(postEntity.likeCount)).orElse(0);
 			int hits = Optional.ofNullable(tuple.get(postEntity.hits)).orElse(0);
 
 			PostDto.PostDtoResponse dto = postDtoMap.computeIfAbsent(postId, id ->
-				new PostDto.PostDtoResponse(nickname, id, imageId, new ArrayList<>(), likeCount, hits, createdAt)
+				new PostDto.PostDtoResponse(nickname, id, imageLocationId, new ArrayList<>(), likeCount, hits, createdAt)
 			);
 
 			if (hashtagContent != null && !dto.hashtags().contains(hashtagContent)) {

--- a/backend/src/main/java/org/example/post/service/PostService.java
+++ b/backend/src/main/java/org/example/post/service/PostService.java
@@ -62,19 +62,20 @@ public class PostService {
 		UserEntity user = findUserByEmail(email);
 
 		// 1. save image file
-		StorageSaveResult storageSaveResult = imageStorageManager.saveResource(image,
-			StorageType.LOCAL_FILE_SYSTEM);
+		StorageSaveResult storageSaveResult = imageStorageManager.saveImage(
+			image, StorageType.LOCAL_FILE_SYSTEM
+		);
 
 		// 2. run image analyze async
 		CompletableFuture.runAsync(() -> {
 			try {
-				imageAnalyzeManager.analyze(storageSaveResult.resourceLocationId());
+				imageAnalyzeManager.analyze(storageSaveResult.imageLocationId());
 			} catch (IOException e) {
 				throw new RuntimeException(e);
 			}
 		}).thenRunAsync(() -> {
 			try {
-				List<String> savedColorList = imageRedisService.saveNewColor(storageSaveResult.resourceLocationId());
+				List<String> savedColorList = imageRedisService.saveNewColor(storageSaveResult.imageLocationId());
 				log.info("Saved Color List : {}", savedColorList.stream().toList());
 			} catch (JsonProcessingException e) {
 				throw new RuntimeException(e);
@@ -85,7 +86,7 @@ public class PostService {
 		PostEntity post = new PostEntity(
 			user,
 			postDto.postContent(),
-			storageSaveResult.resourceLocationId(),
+			storageSaveResult.imageLocationId(),
 			0
 		);
 		postRepository.save(post);
@@ -131,11 +132,11 @@ public class PostService {
 		}
 
 		if (!image.isEmpty()) {
-			StorageSaveResult storageSaveResult = imageStorageManager.saveResource(
+			StorageSaveResult storageSaveResult = imageStorageManager.saveImage(
 				image,
 				StorageType.LOCAL_FILE_SYSTEM
 			);
-			post.updateImage(storageSaveResult.resourceLocationId());
+			post.updateImage(storageSaveResult.imageLocationId());
 		}
 
 		if (!updateRequest.postContent().isEmpty()) {
@@ -192,19 +193,19 @@ public class PostService {
 	public Boolean like(Long postId, String email) throws JsonProcessingException {
 		PostEntity post = findPostById(postId);
 		UserEntity user = findUserByEmail(email);
-		Long resourceLocationId = post.getImageId();
+		Long imageLocationId = post.getImageLocationId();
 
 		// user 는 like 을 한번 만 누를 수 있다.
 		if (existLikePost(user, post)) {
 			// 좋아요를 누른 상태이면, 좋아요 취소를 위해 DB 삭제
 			LikeEntity currentLikePost = likeRepository.findByUserAndPost(user, post);
-			imageRedisService.updateZSetColorScore(resourceLocationId, UpdateScoreType.LIKE_CANCEL);
+			imageRedisService.updateZSetColorScore(imageLocationId, UpdateScoreType.LIKE_CANCEL);
 			post.decreaseLikeCount();
 			likeRepository.delete(currentLikePost);
 			return false;
 		} else {
 			// 좋아요를 누르지 않을 경우 DB에 저장
-			imageRedisService.updateZSetColorScore(resourceLocationId, UpdateScoreType.LIKE);
+			imageRedisService.updateZSetColorScore(imageLocationId, UpdateScoreType.LIKE);
 			post.increaseLikeCount();
 			likeRepository.save(LikeEntity.toEntity(user, post));
 			return true;
@@ -241,7 +242,7 @@ public class PostService {
 	}
 
 	public int updateView(Long postId) throws JsonProcessingException {
-		imageRedisService.updateZSetColorScore(findPostById(postId).getImageId(), UpdateScoreType.VIEW);
+		imageRedisService.updateZSetColorScore(findPostById(postId).getImageLocationId(), UpdateScoreType.VIEW);
 		return postRepository.updateView(postId);
 	}
 

--- a/backend/src/main/java/org/example/scrap/service/ScrapService.java
+++ b/backend/src/main/java/org/example/scrap/service/ScrapService.java
@@ -1,6 +1,5 @@
 package org.example.scrap.service;
 
-import java.util.List;
 import java.util.Optional;
 
 import org.example.exception.common.ApiErrorCategory;
@@ -55,7 +54,7 @@ public class ScrapService {
 				.subCategory(ApiUserErrorSubCategory.USER_SCRAP_DUPLICATION)
 				.build();
 		}
-		imageRedisService.updateZSetColorScore(findPost(postId).getImageId(), UpdateScoreType.SCRAP);
+		imageRedisService.updateZSetColorScore(findPost(postId).getImageLocationId(), UpdateScoreType.SCRAP);
 		scrapRepository.save(
 			ScrapEntity.builder()
 				.post(this.findPost(postId))
@@ -65,7 +64,7 @@ public class ScrapService {
 	}
 
 	public void unscrapPostByPostId(Long postId, String userEmail) throws JsonProcessingException {
-		imageRedisService.updateZSetColorScore(findPost(postId).getImageId(), UpdateScoreType.SCRAP_CANCEL);
+		imageRedisService.updateZSetColorScore(findPost(postId).getImageLocationId(), UpdateScoreType.SCRAP_CANCEL);
 		scrapRepository.deleteByPostAndUser(
 			this.findPost(postId),
 			this.findUserByEmail(userEmail)

--- a/backend/src/main/java/org/example/user/domain/dto/UserDto.java
+++ b/backend/src/main/java/org/example/user/domain/dto/UserDto.java
@@ -44,7 +44,7 @@ public class UserDto {
 		String birth,
 		String nickname,
 		String instaId,
-		Long imageId,
+		Long imageLocationId,
 		int postNum
 	) {
 		public static UserGetInfoResponse toDto(UserEntity userEntity, Integer postNum) {
@@ -55,7 +55,7 @@ public class UserDto {
 				userEntity.getBirth(),
 				userEntity.getNickname(),
 				userEntity.getInstaId(),
-				userEntity.getProfileImageId(),
+				userEntity.getProfileImageLocationId(),
 				postNum
 			);
 		}
@@ -63,7 +63,7 @@ public class UserDto {
 
 	// 회원이 작성한 게시글 조회 응답 DTO
 	public record UserGetPostsResponse(
-		Long imageId,
+		Long imageLocationId,
 		String postContent,
 		List<String> hashtags,
 		Integer likeCount,
@@ -71,13 +71,13 @@ public class UserDto {
 	) {
 		@QueryProjection
 		public UserGetPostsResponse(
-			Long imageId,
+			Long imageLocationId,
 			String postContent,
 			List<String> hashtags,
 			Integer likeCount,
 			Long postId
 		) {
-			this.imageId = imageId;
+			this.imageLocationId = imageLocationId;
 			this.postContent = postContent;
 			this.hashtags = hashtags;
 			this.likeCount = likeCount;

--- a/backend/src/main/java/org/example/user/domain/entity/member/UserEntity.java
+++ b/backend/src/main/java/org/example/user/domain/entity/member/UserEntity.java
@@ -59,7 +59,7 @@ public class UserEntity extends BaseEntity implements UserDetails { // UserDetai
 	@Enumerated(EnumType.STRING)
 	private Role role;
 
-	private Long profileImageId;
+	private Long profileImageLocationId;
 
 	private String provider;
 
@@ -70,7 +70,7 @@ public class UserEntity extends BaseEntity implements UserDetails { // UserDetai
 
 	@Builder
 	public UserEntity(String username, String password, String email, Gender gender, String birth, String nickname,
-		String instaId, Role role, Long profileImageId, String provider, String providerId) {
+		String instaId, Role role, Long profileImageLocationId, String provider, String providerId) {
 		this.username = username;
 		this.password = password;
 		this.email = email;
@@ -79,7 +79,7 @@ public class UserEntity extends BaseEntity implements UserDetails { // UserDetai
 		this.nickname = nickname;
 		this.instaId = instaId;
 		this.role = role;
-		this.profileImageId = profileImageId;
+		this.profileImageLocationId = profileImageLocationId;
 		this.provider = provider;
 		this.providerId = providerId;
 	}
@@ -104,8 +104,8 @@ public class UserEntity extends BaseEntity implements UserDetails { // UserDetai
 	}
 
 	// 이미지도 업데이트
-	public void updateProfileImage(Long profileImageId) {
-		this.profileImageId = profileImageId;
+	public void updateProfileImage(Long profileImageLocationId) {
+		this.profileImageLocationId = profileImageLocationId;
 	}
 
 	@Override

--- a/backend/src/main/java/org/example/user/repository/member/custom/UserRepositoryImpl.java
+++ b/backend/src/main/java/org/example/user/repository/member/custom/UserRepositoryImpl.java
@@ -37,7 +37,7 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
 
 		return posts.stream()
 			.map(postEntity1 -> new UserDto.UserGetPostsResponse(
-				postEntity1.getImageId(),
+				postEntity1.getImageLocationId(),
 				postEntity1.getPostContent(),
 				postEntity1.getHashtagContents(),
 				postEntity1.getLikeCount(),

--- a/backend/src/main/java/org/example/user/service/member/UserService.java
+++ b/backend/src/main/java/org/example/user/service/member/UserService.java
@@ -53,11 +53,11 @@ public class UserService {
 		// TODO: image storage는 ApiException이 아닌 자체적 Exception을 던지도록
 		//       변경될 예정입니다. 후추 try-catch로 변경해야 합니다.
 		if (profileImage != null && !profileImage.isEmpty()) {
-			StorageSaveResult storageSaveResult = imageStorageManager.saveResource(
+			StorageSaveResult storageSaveResult = imageStorageManager.saveImage(
 				profileImage, StorageType.LOCAL_FILE_SYSTEM
 			);
 
-			user.updateProfileImage(storageSaveResult.resourceLocationId());
+			user.updateProfileImage(storageSaveResult.imageLocationId());
 		}
 
 		if(updateRequest != null) {


### PR DESCRIPTION
 1. 기존 ResourceLocationId를 ImageLocationId로 변경했습니다.
     각 엔티티에서 사용하던 imageId 도 imageLocationId로 일괄 통일했습니다.
 2. 엑세스 토큰 Claim에 role이 없는 경우 role = null 이 들어와 null execption이 발생하는 문제 고쳤습니다.
     role이 없으면 `ROLE_NONE`으로 string 설정해줍니다.